### PR TITLE
docs: navio2: hardware: add RPi supported boards

### DIFF
--- a/docs/autopilots/navio2/ardupilot/hardware-setup.md
+++ b/docs/autopilots/navio2/ardupilot/hardware-setup.md
@@ -2,7 +2,9 @@
 
 ArduPilot on Navio2 is working on:
 
+* Raspberry Pi 3 Model A+
 * Raspberry Pi 3 Model B
+* Raspberry Pi 3 Model B+
 * Raspberry Pi 2 Model B
 
 !!! note ""


### PR DESCRIPTION
Add Raspberry Pi supported boards to Navio2 docs