### PR TITLE
Fix some links

### DIFF
--- a/docs/reach/common/tutorials/placing-gcps.md
+++ b/docs/reach/common/tutorials/placing-gcps.md
@@ -25,7 +25,7 @@ To place GCPs with Reach units follow the steps from this guide.
 	</center>
 
 ??? note "Setting RTK on Reach rover over NTRIP"
-	If you have just one Reach receiver, you need to connect it to NTRIP first. [Check this guide for more details](../../tutorials/ntrip-workflow/)
+	If you have just one Reach receiver, you need to connect it to NTRIP first. [Check this guide for more details](../../ntrip-workflow)
 
 ### Create a project
 

--- a/docs/reach/rs/quickstart/first-setup.md
+++ b/docs/reach/rs/quickstart/first-setup.md
@@ -116,8 +116,6 @@ The blue LED will blink rapidly while scanning for networks. Once Reach connects
 
     * Put Reach IP in the address bar and go
 
-    Read more on resolving IP addresses in the [ReachView section](../common/reachview/index.md#resolving-ip).
-
 
 ### Updating ReachView
 

--- a/docs/reach/rs2/reachview/logging.md
+++ b/docs/reach/rs2/reachview/logging.md
@@ -69,9 +69,9 @@ You can see the recording date and time.
 
 There are two buttons on the right side of each log: <img src="../img/reachview/logging/blue-arrow.svg" align="middle" alt="blue arrow" />  button allows to save it, and <img src="../img/reachview/logging/garbage-can.svg" align="middle" alt="red garbage can" /> button deletes it.
 
-Now when the logs are downloaded, you can use [RTKLIB software](../../tutorials/gps-post-processing) from Emlid docs to start working with your data.
+Now when the logs are downloaded, you can use [RTKLIB software](../../common/tutorials/gps-post-processing) from Emlid docs to start working with your data.
 
-Check [PPK guide](../../tutorials/gps-post-processing) in Emlid docs to learn more about PPK. 
+Check [PPK guide](../../common/tutorials/gps-post-processing) in Emlid docs to learn more about PPK. 
 
 
 


### PR DESCRIPTION
1. Fix links to the RTKLIB software and PPK guide in docs: reach: rs2: reachview: logging.md
2. Delete link to resolving IP section in docs: reach: rs: quickstart: first-setup.md
3. Fix link to the Setting RTK on Reach rover over NTRIP in docs: reach: common: tutorials: placing-gcps.md
