### PR TITLE
Fix links in 'quickstart.md' for all devices

### DIFF
--- a/docs/reach/mplus/quickstart.md
+++ b/docs/reach/mplus/quickstart.md
@@ -1,10 +1,9 @@
-## Intro
+# Quickstart
 
+If this is your first time using Reach M+, following these guides will help you to learn the basics. 
 
-If this is your first time using Reach, following these guides will help you to learn the basics. 
-
-* [First setup](../first-setup)
-* [Base and rover setup](../base-rover-setup)
-* [Connecting Reach to the Internet](../connecting-to-the-internet.md)
-* [Working with NTRIP service](../ntrip-workflow.md)
-* [How to download files from Reach](../downloading-files.md)
+* [First setup](../../common/quickstart/first-setup)
+* [Base and rover setup](../../common/quickstart/base-rover-setup)
+* [Connecting Reach to the Internet](../../common/quickstart/connecting-to-the-internet)
+* [Working with NTRIP service](../../common/quickstart/ntrip-workflow)
+* [How to download files from Reach](../../common/quickstart/downloading-files)

--- a/docs/reach/rs/quickstart.md
+++ b/docs/reach/rs/quickstart.md
@@ -1,9 +1,9 @@
 # Quickstart
 
-If this is your first time using Reach, following these guides will help you to learn the basics. Ready to get started?
+If this is your first time using Reach RS/RS+, following these guides will help you to learn the basics. 
 
-* [First setup](quickstart/first-setup.md)
-* [Base and rover setup](quickstart/base-rover-setup.md)
-* [Connecting Reach to the Internet](common/quickstart/connecting-to-the-internet.md)
-* [Working with NTRIP service](common/quickstart/ntrip-workflow.md)
-* [How to download files from Reach](common/quickstart/downloading-files.md)
+* [First setup](../../common/quickstart/first-setup)
+* [Base and rover setup](../../common/quickstart/base-rover-setup)
+* [Connecting Reach to the Internet](../../common/quickstart/connecting-to-the-internet)
+* [Working with NTRIP service](../../common/quickstart/ntrip-workflow)
+* [How to download files from Reach](../../common/quickstart/downloading-files)

--- a/docs/reach/rs2/quickstart.md
+++ b/docs/reach/rs2/quickstart.md
@@ -1,9 +1,9 @@
 # Quickstart
 
-If this is your first time using Reach, following these guides will help you to learn the basics. Ready to get started?
+If this is your first time using Reach RS2, following these guides will help you to learn the basics. 
 
-* [First setup](quickstart/first-setup.md)
-* [Base and rover setup](quickstart/base-rover-setup.md)
-* [Connecting Reach to the Internet](connecting-to-the-internet.md)
-* [Working with NTRIP service](ntrip-workflow.md)
-* [How to download files from Reach](common/quickstart/downloading-files.md)
+* [First setup](../../common/quickstart/first-setup)
+* [Base and rover setup](../../common/quickstart/base-rover-setup)
+* [Connecting Reach to the Internet](../../connecting-to-the-internet)
+* [Working with NTRIP service](../ntrip-workflow)
+* [How to download files from Reach](../../common/quickstart/downloading-files)


### PR DESCRIPTION
Fix links to the rest of the guide in quickstart.md: in docs: reach: rs2,  docs: reach: rs and docs: reach: mplus 