### PR TITLE
Fix links in 'quickstart.md' for all devices

### DIFF
--- a/docs/reach/mplus/quickstart.md
+++ b/docs/reach/mplus/quickstart.md
@@ -2,8 +2,8 @@
 
 If this is your first time using Reach M+, following these guides will help you to learn the basics. 
 
-* [First setup](../../common/quickstart/first-setup)
-* [Base and rover setup](../../common/quickstart/base-rover-setup)
-* [Connecting Reach to the Internet](../../common/quickstart/connecting-to-the-internet)
-* [Working with NTRIP service](../../common/quickstart/ntrip-workflow)
-* [How to download files from Reach](../../common/quickstart/downloading-files)
+* [First setup](common/quickstart/first-setup.md)
+* [Base and rover setup](common/quickstart/base-rover-setup.md)
+* [Connecting Reach to the Internet](common/quickstart/connecting-to-the-internet.md)
+* [Working with NTRIP service](common/quickstart/ntrip-workflow.md)
+* [How to download files from Reach](common/quickstart/downloading-files.md)

--- a/docs/reach/rs/quickstart.md
+++ b/docs/reach/rs/quickstart.md
@@ -2,8 +2,8 @@
 
 If this is your first time using Reach RS/RS+, following these guides will help you to learn the basics. 
 
-* [First setup](../../common/quickstart/first-setup)
-* [Base and rover setup](../../common/quickstart/base-rover-setup)
-* [Connecting Reach to the Internet](../../common/quickstart/connecting-to-the-internet)
-* [Working with NTRIP service](../../common/quickstart/ntrip-workflow)
-* [How to download files from Reach](../../common/quickstart/downloading-files)
+* [First setup](common/quickstart/first-setup.md)
+* [Base and rover setup](common/quickstart/base-rover-setup.md)
+* [Connecting Reach to the Internet](common/quickstart/connecting-to-the-internet.md)
+* [Working with NTRIP service](common/quickstart/ntrip-workflow.md)
+* [How to download files from Reach](common/quickstart/downloading-files.md)

--- a/docs/reach/rs2/quickstart.md
+++ b/docs/reach/rs2/quickstart.md
@@ -2,8 +2,9 @@
 
 If this is your first time using Reach RS2, following these guides will help you to learn the basics. 
 
-* [First setup](../../common/quickstart/first-setup)
-* [Base and rover setup](../../common/quickstart/base-rover-setup)
-* [Connecting Reach to the Internet](../../connecting-to-the-internet)
-* [Working with NTRIP service](../ntrip-workflow)
-* [How to download files from Reach](../../common/quickstart/downloading-files)
+* [First setup](common/quickstart/first-setup.md)
+* [Base and rover setup](common/quickstart/base-rover-setup.md)
+* [Connecting Reach to the Internet](../connecting-to-the-internet/)
+* [Working with NTRIP service](../ntrip-workflow/)
+* [How to download files from Reach](common/quickstart/downloading-files.md) 
+

--- a/docs/templates/index.mdx
+++ b/docs/templates/index.mdx
@@ -1,6 +1,6 @@
 Welcome to your Emlid Reach {{ model }}!
 
-  [![](img/{{ model_path }}/quickstart.png){: style="width: 200px;"}](quickstart{{ '/first-setup' if model == "RS/RS+" }}.md)
+  [![](img/{{ model_path }}/quickstart.png){: style="width: 200px;"}](quickstart.md)
   [![](img/{{ model_path }}/tutorials.png){: style="width: 200px;"}](tutorials.md)
   [![](img/{{ model_path }}/reachview.png){: style="width: 200px;"}](common/reachview)
 


### PR DESCRIPTION
Fix links to the rest of the Quickstart guides in 'quickstart.md' in docs: reach: rs2, docs: reach: rs and docs: reach: mplus.

Fix links to the Reach RS/RS+ Quickstart guide in the 'index.mdx' template in docs: templates.