### PR TITLE
Add links to new CE declarations to 'specs.md' for all devices

### DIFF
--- a/docs/reach/m2/specs.md
+++ b/docs/reach/m2/specs.md
@@ -52,4 +52,4 @@ Reach can both receive power from USB, acting as a device and source power to th
 
 CE Compliance documents can be found here:
 
-* [Reach M2 CE Declaration of conformity](https://files.emlid.com/compliance/CE-Declaration-of-Conformity-Reach-M2.pdf)
+[Reach M2 CE Declaration of conformity](http://files.emlid.com/compliance/CE-Declaration-of-Conformity-Reach-M2.pdf)

--- a/docs/reach/mplus/specs.md
+++ b/docs/reach/mplus/specs.md
@@ -52,4 +52,4 @@ Reach can both receive power from USB, acting as a device and source power to th
 
 CE Compliance documents can be found here:
 
-* [Reach M+ CE Declaration of conformity](https://files.emlid.com/compliance/RM_CE_declaration.pdf)
+[Reach M+ CE Declaration of conformity](http://files.emlid.com/compliance/CE-Declaration-of-Conformity-Reach-MPlus.pdf)

--- a/docs/reach/rs/specs.md
+++ b/docs/reach/rs/specs.md
@@ -30,5 +30,5 @@
 |-------------------------|---------------|
 | Reach RS CE Declaration of conformity | [RRS_CE_declaration [PDF, 322 KB]](https://files.emlid.com/compliance/RRS_CE_declaration.pdf)
 | Reach RS test report main page | [RRS_CE_test_report [PDF, 766 KB]](https://files.emlid.com/compliance/RRS_CE_test_report.pdf)
-| Reach RS+ CE Declaration of conformity | [RRSP_CE_declaration [PDF, 925 KB]](https://files.emlid.com/compliance/RRSP_CE_declaration.pdf)
+| Reach RS+ CE Declaration of conformity | [RRSP_CE_declaration [PDF, 925 KB]](http://files.emlid.com/compliance/CE-Declaration-of-Conformity-Reach-RSPlus.pdf)
 | Reach RS+ test report main page | [RRSP_CE_test_report [PDF, 1.1 MB]](https://files.emlid.com/compliance/RRSP_CE_test_report.pdf)

--- a/docs/reach/rs2/specs.md
+++ b/docs/reach/rs2/specs.md
@@ -27,3 +27,9 @@
 Scan QR code under the SIM card slot cover to see serial number of your Reach RS2.
 
 <p style="text-align:center" ><img src="../img/reachrs2/specs/RS2_QR_code.jpg" style="width: 800px;" /></p>
+
+## Compliance
+
+CE Compliance documents can be found here:
+
+[Reach RS2 CE Declaration of conformity](http://files.emlid.com/compliance/CE-Declaration-of-Conformity-Reach-RS2.pdf)


### PR DESCRIPTION
Add links to new CE declarations to 'specs.md' in docs: reach: m2, docs: reach: rs2, docs: reach: mplus, docs: reach: rs