### PR TITLE
Rename Reach RTK to Reach Module

### DIFF
--- a/reach.yml
+++ b/reach.yml
@@ -86,7 +86,7 @@ nav:
   - Integration with external software:
     - ArduPilot integration: ardupilot-integration.md
     - Bluetooth output and Android mock location: common/tutorials/mock-location.md
-model: RTK
+model: Module
 model_path: reach
 power_port: 'DF13'
 usb: 'Micro-USB'


### PR DESCRIPTION
Change 'model: RTK' to 'model: Module'