### PR TITLE
Fix link in header docs

### DIFF
--- a/edge.yml
+++ b/edge.yml
@@ -1,5 +1,5 @@
 site_name: Edge docs
-site_url: https://emlid.com/edge/
+site_url: https://emlid.com/docs
 docs_dir: docs/autopilots/edge
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/navio2.yml
+++ b/navio2.yml
@@ -1,5 +1,5 @@
 site_name: Navio2 docs
-site_url: https://emlid.com/navio/
+site_url: https://emlid.com/docs
 docs_dir: docs/autopilots/navio2
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reach.yml
+++ b/reach.yml
@@ -1,5 +1,5 @@
 site_name: Reach RTK docs
-site_url: https://emlid.com/reach/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/rtk
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachm-plus.yml
+++ b/reachm-plus.yml
@@ -1,5 +1,5 @@
 site_name: Reach M+ docs
-site_url: https://emlid.com/reach/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/mplus
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachm2.yml
+++ b/reachm2.yml
@@ -1,5 +1,5 @@
 site_name: Reach M2 docs
-site_url: https://emlid.com/reach/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/m2
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachrs.yml
+++ b/reachrs.yml
@@ -1,5 +1,5 @@
 site_name: Reach RS/RS+ docs
-site_url: https://emlid.com/reachrs/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/rs
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachrs2.yml
+++ b/reachrs2.yml
@@ -1,5 +1,9 @@
 site_name: Reach RS2 docs
+<<<<<<< HEAD
 site_url: https://emlid.com/docs
+=======
+site_url: https://emlid.com/
+>>>>>>> parent of 153e174... Revert "Update reachrs2.yml"
 docs_dir: docs/reach/rs2
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachrs2.yml
+++ b/reachrs2.yml
@@ -1,5 +1,5 @@
 site_name: Reach RS2 docs
-site_url: https://emlid.com/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/rs2
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachrs2.yml
+++ b/reachrs2.yml
@@ -1,5 +1,5 @@
 site_name: Reach RS2 docs
-site_url: https://emlid.com/
+site_url: https://emlid.com/reachrs2/
 docs_dir: docs/reach/rs2
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachrs2.yml
+++ b/reachrs2.yml
@@ -1,5 +1,5 @@
 site_name: Reach RS2 docs
-site_url: https://emlid.com/reachrs2/
+site_url: https://emlid.com/
 docs_dir: docs/reach/rs2
 copyright: 'Emlid.com'
 edit_uri: ''


### PR DESCRIPTION
fixed site_url in 7 files
Change site_url to https://emlid.com/docs
Fix correct redirect when click in logo.