### PR TITLE
Add video tutorial on Android mock location section in mock-location.md

### DIFF
--- a/docs/reach/common/tutorials/mock-location.md
+++ b/docs/reach/common/tutorials/mock-location.md
@@ -114,6 +114,14 @@ Reach and Android device are now paired:
 
 ## Android mock location
 
+###Video guide
+
+The video below covers the process of connecting Reach to an Android device for data collection.
+
+<div style="text-align: center;"><iframe width="560" height="315" src="https://www.youtube.com/embed/aC3ti1qynk4" frameborder="0" allowfullscreen></iframe></div>
+
+###Text guide
+
 We provide a guide on how to use Reach with [Lefebure NTRIP Client](https://play.google.com/store/apps/details?id=com.lefebure.ntripclient).
 
 Besides being an NTRIP Client, this app also allows NMEA data input via Bluetooth and supports Android feature called **mock location**. This feature allows substituting your device's built-in GPS receiver with an external location provider.


### PR DESCRIPTION
Add link to the video tutorial in Bluetooth output and Android mock location tutorial in docs: reach: common: tutorials: mock-location.md