### PR TITLE
Change the Emlid logo link to "https://emlid.com/docs" 

### DIFF
--- a/edge.yml
+++ b/edge.yml
@@ -1,5 +1,5 @@
 site_name: Edge docs
-site_url: https://emlid.com/edge/
+site_url: https://emlid.com/docs
 docs_dir: docs/autopilots/edge
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/navio2.yml
+++ b/navio2.yml
@@ -1,5 +1,5 @@
 site_name: Navio2 docs
-site_url: https://emlid.com/navio/
+site_url: https://emlid.com/docs
 docs_dir: docs/autopilots/navio2
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reach.yml
+++ b/reach.yml
@@ -1,5 +1,5 @@
 site_name: Reach Module docs
-site_url: https://emlid.com/reach/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/rtk
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachm-plus.yml
+++ b/reachm-plus.yml
@@ -1,5 +1,5 @@
 site_name: Reach M+ docs
-site_url: https://emlid.com/reach/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/mplus
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachm2.yml
+++ b/reachm2.yml
@@ -1,5 +1,5 @@
 site_name: Reach M2 docs
-site_url: https://emlid.com/reach/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/m2
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachrs.yml
+++ b/reachrs.yml
@@ -1,5 +1,5 @@
 site_name: Reach RS/RS+ docs
-site_url: https://emlid.com/reachrs/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/rs
 copyright: 'Emlid.com'
 edit_uri: ''

--- a/reachrs2.yml
+++ b/reachrs2.yml
@@ -1,5 +1,5 @@
 site_name: Reach RS2 docs
-site_url: https://emlid.com/reachrs2/
+site_url: https://emlid.com/docs
 docs_dir: docs/reach/rs2
 copyright: 'Emlid.com'
 edit_uri: ''


### PR DESCRIPTION
Change links in:
https://docs.emlid.com/reachrs2/
https://docs.emlid.com/reachrs/
https://docs.emlid.com/reachm2/
https://docs.emlid.com/reachm-plus/
https://docs.emlid.com/reach/
https://docs.emlid.com/navio2/
https://docs.emlid.com/edge/