### PR TITLE
Change 'Reach RTK' name to 'Reach Module' in 'firmware-reflashing.mdx'

### DIFF
--- a/docs/templates/reachview/firmware-reflashing.mdx
+++ b/docs/templates/reachview/firmware-reflashing.mdx
@@ -30,7 +30,7 @@ Note that you **do not** need to do this unless you want to bring Reach to its i
 * For Reach RS, install the [Intel Edison Driver](http://files.emlid.com/firmware-reflashing-tool/IntelEdisonDriverSetup1.2.1.exe)
 {%endif%}
 
-{% if model == 'RTK'%}
+{% if model == 'Module'%}
 * Install the [Intel Edison Driver](http://files.emlid.com/firmware-reflashing-tool/IntelEdisonDriverSetup1.2.1.exe)
 {%endif%}
 
@@ -101,13 +101,13 @@ Get the latest ReachView image version and unzip it:
 
 {%endif%}
 
-{%if model == 'RTK'%}
+{%if model == 'Module'%}
 
 <center>
 
-| For Reach RTK |
+| For Reach Module |
 |:-----------:|
-| [**Reach RTK Image v2.22.2 [ZIP, 201.6 MB]**](http://files.emlid.com/images/reach-rs-v2.22.2.zip), [(md5)](http://files.emlid.com/images/reachview-MD5SUMS)     |
+| [**Reach Module Image v2.22.2 [ZIP, 201.6 MB]**](http://files.emlid.com/images/reach-rs-v2.22.2.zip), [(md5)](http://files.emlid.com/images/reachview-MD5SUMS)     |
 
 </center>
 
@@ -178,7 +178,7 @@ Get the latest ReachView image version and unzip it:
 
 {%endif%}
 
-{%if model == 'RTK'%}
+{%if model == 'Module'%}
 
 * Connect Reach {{model}}. Follow the instructions to your device
 
@@ -197,7 +197,7 @@ Get the latest ReachView image version and unzip it:
 
 <p style="text-align:center" ><img src="../img/reachview/firmware-reflashing/{{model_path}}/app-step4-flashing.png" style="width: 300px;" /></p>
 
-{%if model == 'RTK'%}
+{%if model == 'Module'%}
 
 {%else%}
 


### PR DESCRIPTION
Change 'Reach RTK' name to 'Reach Module' and all of the corresponding model settings in 'firmware-reflashing.mdx' of docs: templates: rv: