### PR TITLE
Fix page content for RS/RS+ in firmware-reflashing.mdx

### DIFF
--- a/docs/templates/reachview/firmware-reflashing.mdx
+++ b/docs/templates/reachview/firmware-reflashing.mdx
@@ -71,6 +71,7 @@ Get the latest ReachView image version and unzip it:
 |For Reach RS+|For Reach RS|
 |:-------------:|:----------:|
 |[**Reach RS+ Image v2.22.3 [ZIP, 358 MB]**](http://files.emlid.com/images/reach-plus-v2.22.3.zip), [(md5)](http://files.emlid.com/images/reach-plus-MD5SUMS)|[**Reach RS Image v2.22.3 [ZIP, 183 MB]**](http://files.emlid.com/images/reach-rs-v2.22.3.zip), [(md5)](http://files.emlid.com/images/reachview-MD5SUMS)|
+
 </center>
 {%endif%}
 


### PR DESCRIPTION
Fix spaces in docs: templates: reachview: firmware-reflashing.mdx