### PR TITLE
Fix typos and links in 'sensefly-rtk.md' and 'sensefly-ppk.md' guides

### DIFF
--- a/docs/reach/rs2/sensefly-ppk.md
+++ b/docs/reach/rs2/sensefly-ppk.md
@@ -3,7 +3,7 @@
 In this tutorial, you will find the information on how to perform PPK with senseFly drones and Reach RS2 in eMotion software. 
 
 !!! note ""
-    Step-by-step guide can be also found on [senseFly Knowledge Base.](https://sensefly.zendesk.com/hc/en-us/articles/360010693419-Emlid-Reach-RS2-PPK-Workflow)  
+    Step-by-step guide can be also found on [senseFly Knowledge Base](https://sensefly.zendesk.com/hc/en-us/articles/360010693419-Emlid-Reach-RS2-PPK-Workflow).  
 
 ##Preparing Reach RS2 data 
 
@@ -15,7 +15,7 @@ The video below demonstrates how to place the Reach RS2 base over a known point.
 
 <div style="text-align: center;"><iframe title="Emlid manuals" width="560" height="315" src="https://www.youtube.com/embed/FilRoPVDjCs" allowfullscreen></iframe></div>
 
-To find out other ways of placing the local base station, [consult this guide.](../common/tutorials/placing-the-base/)
+To find out other ways of placing the local base station, [consult this guide](../common/tutorials/placing-the-base/).
 
 The general steps for placing the base receiver are described below.
 
@@ -70,7 +70,7 @@ For Reach RS2, consider the antenna height as the distance between the mark and 
     * Go to 192.168.42.1
 
 
-* Configure constellation choice in the [RTK Settings tab.](../common/reachview/rtk-settings) Our default recommendation is all GNSS enabled at 1 Hz
+* Configure constellation choice in the [RTK Settings tab](../common/reachview/rtk-settings). Our default recommendation is all GNSS enabled at 1 Hz
 
 <p style="text-align:center"><img src="../img/reachrs2/sensefly-ppk/rtk-settings.png" style="width: 600px;"/></p>
 
@@ -84,7 +84,7 @@ For Reach RS2, consider the antenna height as the distance between the mark and 
 
 ###Converting raw data log 
 
-* Download [RTKLIB](http://rtkexplorer.com/download/demo5-b31-binaries/)
+* Download [RTKLIB QT apps](https://files.emlid.com/RTKLIB/rtklib-qt-win-b33.zip)
 
 * [Download raw files from Reach to your PC](https://docs.emlid.com/reachrs2/common/quickstart/downloading-files/#logs)
 

--- a/docs/reach/rs2/sensefly-rtk.md
+++ b/docs/reach/rs2/sensefly-rtk.md
@@ -3,7 +3,7 @@
 In this tutorial, you will find the information on how to survey in RTK with senseFly drones and Reach RS2 via Bluetooth. 
 
 !!! note ""
-    Step-by-step guide can be also found on [senseFly Knowledge Base.](https://sensefly.zendesk.com/hc/en-us/articles/360011254199-Emlid-Reach-RS2-RTK-Workflow) 
+    Step-by-step guide can be also found on [senseFly Knowledge Base](https://sensefly.zendesk.com/hc/en-us/articles/360011254199-Emlid-Reach-RS2-RTK-Workflow). 
 
 ##Setting up Reach RS2
 
@@ -15,7 +15,7 @@ The video below demonstrates how to place the Reach RS2 base over a known point.
 
 <div style="text-align: center;"><iframe title="Emlid manuals" width="560" height="315" src="https://www.youtube.com/embed/FilRoPVDjCs" allowfullscreen></iframe></div>
 
-To find out other ways of placing the local base station, [consult this guide.](../common/tutorials/placing-the-base/)
+To find out other ways of placing the local base station, [consult this guide](../common/tutorials/placing-the-base/).
 
 The general steps for placing the base receiver are described below.
 
@@ -139,7 +139,7 @@ For Reach RS2, consider the antenna height as the distance between the mark and 
 
 * Turn on the correction output via Bluetooth
 
-* Choose the base position mode and averaging time. In the example below, it is Average Single. You can find out more about different base position modes in [this guide.]()
+* Choose the base position mode and averaging time. In the example below, it is Average Single. You can find out more about different base position modes in [this guide.](../common/tutorials/placing-the-base/)
 
 <p style="text-align:center"><img src="../img/reachrs2/sensefly-rtk/pc-connection/correction-output-bt.png" style="width: 600px;"/></p>
 
@@ -185,7 +185,7 @@ You will need to find out what COM port on your PC is used by Reach RS2. For tha
 
 <p style="text-align:center"><img src="../img/reachrs2/sensefly-rtk/pc-connection/putty-open.png" style="width: 400px;"/></p>
 
-You can so the same in the Serial tab:
+You can do the same in the Serial tab:
 
 * Go to the Serial tab
 
@@ -260,7 +260,7 @@ Now you can see the RTK tab enabled on your Mission panel on your left.
 * Press *Open base-drone datastream*
 
 !!! note ""
-    If you are testing the set-up inside, the GPS and GLONASS fields will show *Not sufficient* message
+    If you are testing the setup inside, the GPS and GLONASS fields will show *Not sufficient* message
 
 * Check the base position the drone receives 
 


### PR DESCRIPTION
Update link to the RTKLib app in 'sensefly-ppk.md' of docs: reach: rs2.
Fix typos and link in the 'sensefly-rtk.md' of docs: reach: rs2.