### PR TITLE
Fix a link in 'ardupilot-integration.mdx'

### DIFF
--- a/docs/templates/ardupilot-integration.mdx
+++ b/docs/templates/ardupilot-integration.mdx
@@ -1,6 +1,6 @@
 {% if model == "Module" %}
 !!! tip ""
-	Reach {{model} has been replaced with [Reach M+](https://emlid.com/reach). Documentation for Reach M+ can be found [here](https://docs.emlid.com/reachm-plus/).
+	Reach Module has been replaced with [Reach M+](https://emlid.com/reach). Documentation for Reach M+ can be found [here](https://docs.emlid.com/reachm-plus/).
 {% endif %}
 
 Since ReachView version **0.3.0** Reach supports RTK-enhanced coordinates output to Navio2, Edge, and Pixhawk autopilots. To make this possible, we implemented a custom GPS protocol **ERB** (Emlid Reach Binary protocol).


### PR DESCRIPTION
Fix a link in the 'ardupilot-integration.mdx' of the docs: templates.