### PR TITLE
docs: autopilots: common: dev: video-streaming.md update link to Homebrew installer

### DIFF
--- a/docs/autopilots/common/dev/video-streaming.md
+++ b/docs/autopilots/common/dev/video-streaming.md
@@ -47,7 +47,7 @@ Here's the app in action
 The simplest way is to use brew. To install it run the following in your Mac terminal:
 
 ```bash
-user@mac: ~ $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+user@mac: ~ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 user@mac: ~ $ brew update
 user@mac: ~ $ brew install gstreamer gst-libav gst-plugins-ugly gst-plugins-base gst-plugins-bad gst-plugins-good
 ```


### PR DESCRIPTION
Homebrew installer has been updated and was replaced by it's shell version. Updated old link to the installer:
` /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)`