### PR TITLE
Fix typo in LED status for Reach RS2

### DIFF
--- a/docs/reach/rs2/led-status.md
+++ b/docs/reach/rs2/led-status.md
@@ -17,7 +17,7 @@ The lights above the power button indicate the level of the battery charge.
 | <br><br><br><br> <div style="text-align: center;">    Full charge   </div> |  <br>  <div style="text-align: center;"><img src="../img/reachrs2/led-status/full_battery.png" style="height: 150px;"></div>  |
 | <br><br><br><br> <div style="text-align: center;">    Charging   </div> |  <br>  <div style="text-align: center;"><img src="../img/reachrs2/led-status/charging.gif" style="height: 150px;"></div>  |
 | <br><br><br><br> <div style="text-align: center;">    Low battery   </div> |  <br>  <div style="text-align: center;"><img src="../img/reachrs2/led-status/low_battery.png" style="height: 150px;"></div>  |
-| <br><br><br><br> <div style="text-align: center;">    Not ehough charge to boot   </div> |  <br>  <div style="text-align: center;"><img src="../img/reachrs2/led-status/not_enough_charge_to_boot.gif" style="height: 150px;"></div>  |
+| <br><br><br><br> <div style="text-align: center;">    Not enough charge to boot   </div> |  <br>  <div style="text-align: center;"><img src="../img/reachrs2/led-status/not_enough_charge_to_boot.gif" style="height: 150px;"></div>  |
 | <br><br><br><br> <div style="text-align: center;">    Turning OFF   </div> |  <br>  <div style="text-align: center;"><img src="../img/reachrs2/led-status/turning-off.gif" style="height: 150px;"></div>  |
 
 


### PR DESCRIPTION
Fix typo in docs: reach: rs2: led-status.md