### PR TITLE
Add a note to power-supply.mdx template for M2

### DIFF
--- a/docs/templates/power-supply.mdx
+++ b/docs/templates/power-supply.mdx
@@ -7,6 +7,11 @@
 
 Emlid Reach {{ model }} module can be powered using **Micro-USB** port or **{{ power_port }}** ports. Power circuit is shared for all ports, so when you power the device over one port it will pass power to other ports.
 
+{% if model == "M2" %}
+!!! note "" 
+	Make sure that you have a stable power source for Reach M2. We recommend using USB 3.0 or 5V source with up to 3A. Only the red LED lights up when M2 lacks power.
+{% endif %}
+
 !!! danger "Attention"
     Do not plug two power supplies at the same time as it may damage the device.
 


### PR DESCRIPTION
Add a note on a stable power source for Reach M2 in docs: templates: power-supply.mdx.