### PR TITLE
Fix 2 x 'button' typo in ardupilot-integration.mdx

### DIFF
--- a/docs/templates/ardupilot-integration.mdx
+++ b/docs/templates/ardupilot-integration.mdx
@@ -97,7 +97,7 @@ Now configure position output:
 * Choose **UART** or **USB-to-PC** as the device
 * Choose the desired baud rate (38400 for default)
 * Choose **NMEA** as position output format
-* Hit *Apply* button button to save settings
+* Hit *Apply* button to save settings
 
 <div style="text-align: center;"><img src="../img/{{ model_path }}/ardupilot-integration/reach-position-output-nmea.png" style="width: 100%;"></div>
 
@@ -190,7 +190,7 @@ Let's configure our Reach base device:
 * Choose TCP in Correction output options
 * Set **Server** in Role field
 * Set 9000 as Port
-* Hit *Apply* button button to save settings
+* Hit *Apply* button to save settings
 
 <div style="text-align: center;"><img src="../img/{{ model_path }}/ardupilot-integration/reach-base-mode.png" style="width: 100%;"></div>
 


### PR DESCRIPTION
Delete the repetitive words 'button' in docs: templates: ardupilot-integration.mdx