### PR TITLE
Change link to Ardupilot's binary in installation-and-running.md

### DIFF
--- a/docs/autopilots/common/ardupilot/installation-and-running.md
+++ b/docs/autopilots/common/ardupilot/installation-and-running.md
@@ -194,7 +194,7 @@ Where 192.168.1.2 is the IP address of the GCS, not RPi.
 Navio is supported in ArduPilot upstream and if you'd like to build the binary yourself please proceed to the [Building from sources](building-from-sources.md). Also you can download the latest stable binary files from ArduPilot buildserver. To download arducopter binary:
 
 ```bash
-pi@navio: ~ $ wget http://firmware.eu.ardupilot.org/Copter/stable/navio2/arducopter
+pi@navio: ~ $ wget https://firmware.ardupilot.org/Copter/stable/navio2/arducopter
 pi@navio: ~ $ chmod +x arducopter
 ```
 In case of use helicopter, change tail of the link. For example `/navio2-heli/arducopter-heli`. Supported vehicle types are listed below:


### PR DESCRIPTION
Change link in docs: autopilots: common: ardupilot: installation-and-running.md at the 'Launching a custom ArduPilot binary' paragraph for wget to https://firmware.ardupilot.org/Copter/stable/navio2/arducopter