### PR TITLE
Fix Navio2 docs

### DIFF
--- a/docs/autopilots/common/ardupilot/building-from-sources.md
+++ b/docs/autopilots/common/ardupilot/building-from-sources.md
@@ -38,12 +38,10 @@ If you would like to add the compiler to the PATH permanently edit /etc/environm
 
 These steps are the same both for compiling ArduPilot directly on Raspberry Pi and cross-compiling.
 
-Download the ArduPilot code and update submodules:
+Download the ArduPilot code:
 
 ```bash
 git clone https://github.com/ArduPilot/ardupilot.git
-cd ardupilot
-git submodule update --init --recursive
 ```  
 
 Checkout to a specific tag in order not to fly off master.
@@ -54,6 +52,11 @@ For example, to build a copter binary:
 git checkout ArduCopter-stable
 or
 git checkout ArduCopter-beta
+```
+
+Update the submodules:
+```bash
+git submodule update --init --recursive
 ```
 
 Note that Waf should always be called from the ardupilot's root directory.

--- a/docs/autopilots/navio2/dev/adc.md
+++ b/docs/autopilots/navio2/dev/adc.md
@@ -40,4 +40,6 @@ Mapping between A0 - A5 and ADC:
 
 Numbers of A0 - A5 channels correspond to ArduPilot's ADC channels.
 
+The real values of power module voltage and current could be calculated by multiplying to the respective coefficients. The multiplier for voltage (A2) is 11.3. Coefficient for current (A3) is 17.0.
+
 For further information see source code. Pay attention to ```adc.init()``` and ```adc.read()``` functions. ```adc.init()``` function initialize 6 ADC channels. After that it's possible to read value of channels 0-5 with ```adc.read()``` function. It takes channel number as an argument. 


### PR DESCRIPTION
Edit command order in docs: autopilots: common: ardupilot: building-from-sources.md
Add voltage and current coefficients in docs: autopilots: navio2: dev: adc.md