### PR TITLE
 Fix link in Ardupilot Integration guide

### DIFF
--- a/docs/templates/ardupilot-integration.mdx
+++ b/docs/templates/ardupilot-integration.mdx
@@ -10,7 +10,7 @@ Here is a demo video with our results:
 
 ## ERB Protocol specification
 
-Protocol description is available [here](https://files.emlid.com/ERB.pdf).
+Protocol description is available [here](https://files.emlid.com/erb/ERB-0.1.0-v7.pdf).
 
 ## Requirements
 


### PR DESCRIPTION
Fix link to new ERB protocol in docs: templates: ardupilot-integration.mdx