### PR TITLE
Add a tip on mobile data in First Setup guide

### DIFF
--- a/docs/templates/quickstart/first-setup/first-setup-m.mdx
+++ b/docs/templates/quickstart/first-setup/first-setup-m.mdx
@@ -104,6 +104,9 @@ Reach {{model}} is now broadcasting Wi-Fi.
 
 ### Connecting to Reach {{model}}
 
+!!! tip "Using Reach with Android device"
+    Turn off the mobile data on your device before connecting to Reach's hotspot.
+
 * Open a list of Wi-Fi networks on your smartphone, tablet or laptop
 
 * Connect to a network named **reach:xx:xx** 

--- a/docs/templates/quickstart/first-setup/first-setup-rs.mdx
+++ b/docs/templates/quickstart/first-setup/first-setup-rs.mdx
@@ -71,6 +71,9 @@ Hold the power button for 3 seconds to turn Reach RS2 on. After about 30 seconds
 
 ### Connecting to Reach {{model}}
 
+!!! tip "Using Reach with Android device"
+    Turn off the mobile data on your device before connecting to Reach's hotspot.
+
 * Open a list of Wi-Fi networks on your smartphone/PC
 
 * Connect to a network named **reach:xx:xx**


### PR DESCRIPTION
Add a tip on turning off the mobile data for Reach M2/M+ in docs: templates: quickstart: first-setup-m.mdx.
Add a tip on turning off the mobile data for Reach RS2 and Reach RS/RS+ in docs: templates: quickstart: first-setup-rs.mdx.