### PR TITLE
Fix typo in Reach M2/M+ Base and Rover template

### DIFF
--- a/docs/templates/quickstart/base-rover-setup/base-rover-setup-m.mdx
+++ b/docs/templates/quickstart/base-rover-setup/base-rover-setup-m.mdx
@@ -1,6 +1,6 @@
 ## Intro
 
-This tutorial will show how to two set up two Reach {{model}} devices as a base and a rover with correction link over Wi-Fi.
+This tutorial will show how to set up two Reach {{model}} devices as a base and a rover with correction link over Wi-Fi.
 
 !!! tip "Other use cases"
     For setting NTRIP base corrections, [follow the steps from "Working with NTRIP service" guide.](../ntrip-workflow)


### PR DESCRIPTION
Fix typo in docs: templates: quickstart: base-rover-setup: base-rover-setup-m.mdx