### PR TITLE
Add notes on ERB format deprecation

### DIFF
--- a/docs/reach/common/reachview/logging.md
+++ b/docs/reach/common/reachview/logging.md
@@ -51,6 +51,9 @@ NMEA 0183 is the most popular standard in the industry. It is usually supported 
 
 * **ERB**
 
+!!! note ""
+    ERB format is deprecated.
+	
 ERB format is used for communication with Ardupilot.
 
 ###Base corrections

--- a/docs/reach/rs2/reachview/logging.md
+++ b/docs/reach/rs2/reachview/logging.md
@@ -51,6 +51,9 @@ NMEA 0183 is the most popular standard in the industry. It is usually supported 
 
 * **ERB**
 
+!!! note ""
+    ERB format is deprecated.
+
 ERB format is used for communication with Ardupilot.
 
 ###Base corrections

--- a/docs/templates/ardupilot-integration.mdx
+++ b/docs/templates/ardupilot-integration.mdx
@@ -10,6 +10,9 @@ Here is a demo video with our results:
 
 ## ERB Protocol specification
 
+!!! note ""
+    ERB format is deprecated. We recommend using industry-standard NMEA format instead.
+
 Protocol description is available [here](https://files.emlid.com/erb/ERB-0.1.0-v7.pdf).
 
 ## Requirements

--- a/docs/templates/reachview/position-output.mdx
+++ b/docs/templates/reachview/position-output.mdx
@@ -20,6 +20,10 @@ The most popular standard in the industry. Supported messages: GNRMC, GNGGA, GPG
 Protocol definition can be found in [RTKLIB ver. 2.4.2 Manual [PDF, 6.1 MB]](http://www.rtklib.com/prog/manual_2.4.2.pdf) on page 102.
 
 #### ERB
+
+!!! note ""
+    ERB format is deprecated.
+	
 Used for communication to Ardupilot, [protocol description can be found by following this link [PDF, 202 KB]](https://files.emlid.com/ERB.pdf).
 
 


### PR DESCRIPTION
Add notes about ERB format to the guides in:

- docs: reach: common: reachview: logging.md
- docs: reach: rs2: reachview: logging.md
- docs: templates: reachview: position-ouput.mdx
- docs: templates: ardupilot-integration.mdx