### PR TITLE
Fix note in Power-supply.mdx template

### DIFF
--- a/docs/templates/power-supply.mdx
+++ b/docs/templates/power-supply.mdx
@@ -9,7 +9,7 @@ Emlid Reach {{ model }} module can be powered using **Micro-USB** port or **{{ p
 
 {% if model == "M2" %}
 !!! note "" 
-	Make sure that you have a stable power source for Reach M2. We recommend using USB 3.0 or 5V source with up to 3A. Only the red LED lights up when M2 lacks power.
+	Make sure that you have a stable power source for Reach M2. We recommend using USB 3.0 or 4.75 - 5.5V source with up to 3A. Only the red LED lights up when M2 lacks power.
 {% endif %}
 
 !!! danger "Attention"


### PR DESCRIPTION
Fix note about recommended power sources for Reach M2 in docs: templates: power-supply.mdx.