### PR TITLE
docs: common: rv3: add new vertical datums that use GEOID12B for USA

### DIFF
--- a/docs/reach/common/reachview3/countries/usa.md
+++ b/docs/reach/common/reachview3/countries/usa.md
@@ -12,11 +12,13 @@ Choose one of the available vertical datums:
 
 * `ASVD02 height`
 * `GUVD04 height`
-* `NAVD88 depth`
 * `NAVD88 height`
+* `NAVD88(GEOID12B) height`
 * `NMVD03 height`
 * `PRVD02 height`
+* `PRVD02(GEOID12B) height`
 * `VIVD09 height`
+* `VIVD09(GEOID12B) height`
 
 The following geoids are used to perform the transformation:
 
@@ -24,9 +26,9 @@ The following geoids are used to perform the transformation:
 * `GEOID18`
 
 !!! note ""
-	* Projects based on the `NAD83(2011)` datum are compatible with `NAVD88 height`, `PRVD02 height`, and `VIVD09 height` vertical datums that use the `GEOID18` geoid
+	* Projects based on the `NAD83(2011)` datum are compatible with `NAVD88 height`, `PRVD02 height`, and `VIVD09 height` vertical datums that use the `GEOID18` geoid, and with NAVD88(GEOID12B) height`, `PRVD02(GEOID12B) height`, and `VIVD09(GEOID12B) height` vertical datums that use the `GEOID12B` geoid
 	* Projects based on the `NAD83(MA11)` datum are compatible with `GUVD04 height` and `NMVD03 height` vertical datums that use the `GEOID12B` geoid
-	* Projects based on the `NAD83(MA11)` datum are compatible with the `ASVD02 height` vertical datum that also uses the `GEOID12B` geoid
+	* Projects based on the `NAD83(PA11)` datum are compatible with the `ASVD02 height` vertical datum that also uses the `GEOID12B` geoid
 
 ## Base Setup
 


### PR DESCRIPTION
Add some new vertical CRSs to support the legacy GEOID12B in USA:
    - `NAVD88(GEOID12B) height`, used in USA - CONUS and Alaska
    - `NAVD88(GEOID12B) height (ftUS)`, used in USA - CONUS and Alaska
    - `NAVD88(GEOID12B) height (ft)`, used in USA - AZ MI MT ND OR SC
    - `VIVD09(GEOID12B) height`, used in the Virgin Islands
    - `PRVD02(GEOID12B) height`, used in Puerto Rico

Please, don't merge it for a while.