### PR TITLE
Add the note in ardupilot-integration.mdx

### DIFF
--- a/docs/templates/ardupilot-integration.mdx
+++ b/docs/templates/ardupilot-integration.mdx
@@ -69,6 +69,9 @@ To provide RTK solution to Pixhawk, Reach {{ model }} needs to be connected via 
 
 Connect Reach's **{{ power_port }}** port with Navio's **UART** port.
 
+!!! note ""
+    Navio2 may not provide enough power for Reach {{ model }} over UART in some cases.
+
 ## Connecting Reach {{ model }} to Navio2 over USB
 
 <div style="text-align: center;"><img src="../img/{{ model_path }}/ardupilot-integration/navio2-reach-usb.jpg" style="width: 500px;"></div>


### PR DESCRIPTION
Add the note for Connecting Reach M2 to Navio2 over UART in docs: templates: ardupilot-integration.mdx.