### PR TITLE
Fix the links in firmware-reflashing.mdx

### DIFF
--- a/docs/templates/reachview/firmware-reflashing.mdx
+++ b/docs/templates/reachview/firmware-reflashing.mdx
@@ -13,7 +13,7 @@ Note that you **do not** need to do this unless you want to bring Reach to its i
 	
 |Windows|Ubuntu|macOS|
 |:-------------:|:----------:|:-----------:|
-|[Download [EXE, 85.9 MB]](http://files.emlid.com/flash-tools/win/reach-firmware-flash-tool_1.5.0_setup.exe)|[Download [DEB, 66.4 MB]](http://files.emlid.com/flash-tools/linux/reach-firmware-flash-tool_1.5.0_amd64.deb)| [Download [DMG, 61.3 MB]](http://files.emlid.com/flash-tools/macos/Reach.Firmware.Flash.Tool.1.5.0.dmg)|
+|[Download [EXE, 85.9 MB]](https://files.emlid.com/flash-tools/win/reach-firmware-flash-tool_1.5.0_setup.exe)|[Download [DEB, 66.4 MB]](https://files.emlid.com/flash-tools/linux/reach-firmware-flash-tool_1.5.0_amd64.deb)| [Download [DMG, 61.3 MB]](https://files.emlid.com/flash-tools/macos/Reach.Firmware.Flash.Tool.1.5.0.dmg)|
 
 </center>
 


### PR DESCRIPTION
Fix the links in Reach Firmware Flash Tool installation in docs: templates: reachview: firmware-reflashing.mdx.