### PR TITLE
Fix Wi-Fi naming

### DIFF
--- a/docs/autopilots/edge/qgc/wifi-setup.md
+++ b/docs/autopilots/edge/qgc/wifi-setup.md
@@ -1,24 +1,24 @@
 
 ## Overview
-Open QGroundControl, go to ``Setup`` menu and select ``WiFi`` tab. You will see the window.
+Open QGroundControl, go to ``Setup`` menu and select ``Wi-Fi`` tab. You will see the window.
 
 <div style="text-align: center;"><img src="../../img/qgc/wifi/main-page.png"></div><br>
 
-* ``Box 1`` displays current WiFi status:
-    * *Access point mode* (Default state) - Edge works as hotspot and share WiFi signal with other clients.
-    * *Client mode* - Edge is connected to selected WiFi network.
+* ``Box 1`` displays current Wi-Fi status:
+    * *Access point mode* (Default state) - Edge works as hotspot and share Wi-Fi signal with other clients.
+    * *Client mode* - Edge is connected to selected Wi-Fi network.
 
 !!! note ""
-	You also can check status of WiFi in a ``Summary`` tab.
+	You also can check status of Wi-Fi in a ``Summary`` tab.
 
 
 * ``Box 2`` displays list of saved networks (stored on Edge).
 You can add/delete and connect to a network. If some network is set by default, you can switch
-between WiFi modes by clicking on *switch* button in Box 1.
+between Wi-Fi modes by clicking on *switch* button in Box 1.
 
 ## Switch to client mode and back
 
-Click on ``Add`` button. You will see the dialog with WiFi preferences. Enter 
+Click on ``Add`` button. You will see the dialog with Wi-Fi preferences. Enter 
 SSID, security type and password, if need.
 
 <div style="text-align: center;"><img src="../../img/qgc/wifi/add-wifi-dialog.png"></div><br>
@@ -33,14 +33,14 @@ You will see *Switching...* message and Edge will be disconnected.
 
 <div style="text-align: center;"><img src="../../img/qgc/wifi/switching.png"></div><br>
 !!! note ""
-    If Edge WiFi LED has
+    If Edge Wi-Fi LED has
     a green color - everything is well, otherwise this means that you made a mistake in SSID or password
-    of WiFi network. (More about [WiFi LEDs](../led-status.md))
+    of Wi-Fi network. (More about [Wi-Fi LEDs](../led-status.md))
 !!! tip ""
-    ``Switch`` button colors are the same as colors on Edge WiFi indicator.
+    ``Switch`` button colors are the same as colors on Edge Wi-Fi indicator.
 	Green for Client mode and Blue for Access Point.
 
-Connect your computer to WiFi network (to which an Edge is connected).
+Connect your computer to Wi-Fi network (to which an Edge is connected).
 Go to ``General Settings`` and choose ``Comm Links``. Disconnect from previously created comm link  
 (see [Configuring QGroundControl for Edge](../quickstart.md#qgcconf)). Add new IP of Edge by type ``edge.local``.
 
@@ -49,7 +49,7 @@ Go to ``General Settings`` and choose ``Comm Links``. Disconnect from previously
     On Windows for getting IP address via ``edge.local`` you should download and install [Bonjour](https://support.apple.com/kb/dl999?locale=en_US).
 
 Save all and push on ``Connect``. Return back to ``Setup`` menu. If everything is done well, QGC will connect to an
-Edge via WiFi.
+Edge via Wi-Fi.
 
 <div style="text-align: center;"><img src="../../img/qgc/wifi/client-mode.png"></div><br>
 

--- a/edge.yml
+++ b/edge.yml
@@ -69,7 +69,7 @@ nav:
   - 'Logging': 'qgc/logging.md'
   - 'RC Input and Output': 'qgc/rcinput-and-output.md'
   - 'Video streaming': 'qgc/video.md'
-  - 'WiFi setup': 'qgc/wifi-setup.md'
+  - 'Wi-Fi setup': 'qgc/wifi-setup.md'
   - 'Additional parameters': 'qgc/parameters.md'
   - 'Sensors temperature': 'qgc/sensor-temperature.md'
 - LED status: 'led-status.md'


### PR DESCRIPTION
Fix Wi-Fi naming in edge.yml and wifi-setup.md in docs: autopilots: edge: qgc.