### PR TITLE
docs: common: rv3: add new vertical datums for France and Croatia

### DIFF
--- a/docs/reach/common/reachview3/countries/austria.md
+++ b/docs/reach/common/reachview3/countries/austria.md
@@ -19,7 +19,7 @@ The following geoids are used to perform the transformation:
 * `GV_Hoehengrid_plus_Geoid_V`
 
 !!! note ""
-	The `EVRF2000 Austria height` vertical datum uses the`GEOID_GRS80_Oesterreich` geoid. The `GHA height` vertical datum uses the `GV_Hoehengrid_plus_Geoid_V2` geoid.
+	The `EVRF2000 Austria height` vertical datum uses the `GEOID_GRS80_Oesterreich` geoid. The `GHA height` vertical datum uses the `GV_Hoehengrid_plus_Geoid_V2` geoid.
 
 ## Base Setup
 

--- a/docs/reach/common/reachview3/countries/croatia.md
+++ b/docs/reach/common/reachview3/countries/croatia.md
@@ -1,0 +1,22 @@
+# Croatia
+
+## Rover Setup
+
+### Coordinate System
+
+Choose a coordinate system based on the `HTRS96` datum (such as `HTRS96 / Croatia TM`).
+
+### Vertical Datum
+
+Choose the `HVRS71 height` vertical datum.
+
+The `HRG2009` geoid is used to perform the transformation.
+
+## Base Setup
+
+Your base or NTRIP service should be in `HTRS96`.
+
+!!! note ""
+	The `HTRS96` datum is a national realization of `ETRS89`.
+
+When setting up a base station on a benchmark, enter `HTRS96` geographic coordinates (lat/long) and ellipsoidal height in the ReachView 3 *Settings / Base mode*.

--- a/docs/reach/common/reachview3/countries/france.md
+++ b/docs/reach/common/reachview3/countries/france.md
@@ -8,9 +8,18 @@ Choose a coordinate system based on the `RGF93` datum (such as `RGF93 / CC42`).
 
 ### Vertical Datum
 
-Choose the `NGF-IGN69 height` vertical datum.
+Choose one of the available vertical datums:
 
-The `RAF18` geoid is used to perform the transformation.
+* `NGF-IGN69 height`
+* `NGF-IGN69(RAF09) height`
+
+The following geoids are used to perform the transformation:
+
+* `RAF09`
+* `RAF18`
+
+!!! note ""
+	The `NGF-IGN69 height` vertical datum uses the `RAF18` geoid. The `NGF-IGN69(RAF09) height` vertical datum uses the `RAF09` geoid.
 
 ## Base Setup
 

--- a/docs/reach/common/reachview3/crs-setup.md
+++ b/docs/reach/common/reachview3/crs-setup.md
@@ -25,6 +25,7 @@ Find your country or region in the list and follow the steps to specify an appro
 * [Brazil](../countries/brazil)
 * [Canada](../countries/canada)
 * [Canary Islands](../countries/canary-islands)
+* [Croatia](../countries/croatia)
 * [Denmark](../countries/denmark)
 * [Estonia](../countries/estonia)
 * [Finland](../countries/finland)


### PR DESCRIPTION
Following changes will become available in the upcoming app release:
- Add new vertical datums for Croatia
- Add new vertical datums that use RAF09 for France

Some style fixes:
- Add a missing space for Austria doc

