### PR TITLE
Add the character in ardupilot-integration.mdx

### DIFF
--- a/docs/templates/ardupilot-integration.mdx
+++ b/docs/templates/ardupilot-integration.mdx
@@ -69,7 +69,7 @@ To provide RTK solution to Pixhawk, Reach {{ model }} needs to be connected via 
 
 Connect Reach's **{{ power_port }}** port with Navio's **UART** port.
 
-{% if model == "M2"}
+{% if model == "M2"%}
 
 !!! note ""
     Navio2 may not provide enough power for Reach M2 over UART in some cases.


### PR DESCRIPTION
Add the closing character in the Ardupilot integration template in docs: templates: ardupilot-integration.mdx